### PR TITLE
add check for openbsd

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -22,7 +22,7 @@
               'cflags!': [ '-fno-exceptions', '-fmax-errors=0', '`icu-config --cppflags`' ],
               'libraries': [ '`icu-config --ldflags`' ],
               'conditions': [
-                ['OS=="freebsd"', {
+                ['OS=="freebsd" or OS=="openbsd"', {
                   'include_dirs': [
                       '/usr/local/include'
                   ],


### PR DESCRIPTION
OpenBSD puts the dependencies in the same location as Free.

Output of `npm test`:

```
> node-stringprep@0.7.0 test /home/qbit/Development/node-stringprep
> grunt test

Running "mochacli:all" (mochacli) task
Cannot load StringPrep-0.7.0 bindings (using fallback). You may need to `npm install node-stringprep`
Cannot load StringPrep-0.7.0 bindings (using fallback). You may need to `npm install node-stringprep`


  ✓ Should not leak 
  ✓ Should convert to ASCII 
  ✓ Should throw on error 
  ✓ Should convert unassigned code point 
  ✓ Should error on non-STD3 char 
  ✓ Should convert to Unicode 
  ✓ Should convert unassigned code point 
  Should use JS fallbacks for StringPrep
    ✓ Should throw on unknown icu-profile 
    ✓ Should perform a 'nameprep' 
    ✓ Should perform a 'nodeprep' 
    ✓ Should preform a 'resourceprep' 
    ✓ Can't handle other profiles 

  Can disable fallbacks
    ✓ Should allow javascript fallbacks to be disabled 
    ✓ Should allow javascript fallbacks to be re-enabled 

  'isNative' method test
    ✓ Reports true with native 
    ◦ Reports false without native: Cannot load StringPrep-0.7.0 bindings (using fallback). You may need to `npm install node-stringprep`
    ✓ Reports false without native 


  16 passing (13ms)


Running "jshint:allFiles" (jshint) task
>> 6 files lint free.

Done, without errors.
```