### PR TITLE
Keeps errors returned by libicu prepare (nodexmpp/node-stringprep#65)

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,15 +61,14 @@ StringPrep.prototype.useJsFallbacks = true
 
 StringPrep.prototype.prepare = function(value) {
     this.value = value
-    try {
-        if (this.stringPrep) {
-            return this.stringPrep.prepare(this.value)
-        }
-    } catch (e) {}
-    if (false === this.useJsFallbacks) {
+
+    if (this.stringPrep) {
+        return this.stringPrep.prepare(this.value)
+    } else if (this.useJsFallbacks) {
+        return this.jsFallback()
+    } else {
         throw new Error(this.LIBICU_NOT_AVAILABLE)
     }
-    return this.jsFallback()
 }
 
 StringPrep.prototype.isNative = function() {


### PR DESCRIPTION
Only attempt to use the javascript fallback routines when the native
libicu function is not available. This fixes two issues:
1) Overwriting the libicu error with a success from the fallback
2) Reporting a LIBICU_NOT_AVAILABLE error when fallbacks are disabled
and libicu is present, but returns an error

Addresses issue #65